### PR TITLE
fix compress writer

### DIFF
--- a/writer/compress_test.go
+++ b/writer/compress_test.go
@@ -33,7 +33,7 @@ func TestCompressWriter_Write_CompressGzip(t *testing.T) {
 	w := writer.NewCompressWriter(buffer, writer.CompressGzip, 2)
 
 	i, err := w.Write([]byte("fake_data"))
-	assert.Equal(t, 9, i)
+	assert.Equal(t, 33, i)
 	assert.Nil(t, err)
 }
 
@@ -43,6 +43,6 @@ func TestCompressWriter_Write_CompressZlib(t *testing.T) {
 	w := writer.NewCompressWriter(buffer, writer.CompressZlib, 2)
 
 	i, err := w.Write([]byte("fake_data"))
-	assert.Equal(t, 9, i)
+	assert.Equal(t, 21, i)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
_Before_ we just decorate the given writer `writer, err = gzip.NewWriterLevel(w.Writer, w.compressionLevel)` **but** the gzip/zlibWriter call writer.Write **more than once** in order to compress input

_Now_ we use a buffer with gzip/zlibWriter and send **once** the compressed data to the given writer 

PS: it seems gzip/zlibWriter write compressed data when `gzip/zlibWriter.Close()` was called