### PR TITLE
Memory handler

### DIFF
--- a/handler/memory.go
+++ b/handler/memory.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"sync"
+
+	"github.com/gol4ng/logger"
+)
+
+// Memory will store Entry to slice entries
+// mainly develop for testing purpose in order to do some entries assertion
+type Memory struct {
+	mu      sync.Mutex
+	entries []logger.Entry
+}
+
+func (s *Memory) lock() func() {
+	s.mu.Lock()
+	return func() { s.mu.Unlock() }
+}
+
+// Handle act as logger.HandlerInterface
+func (s *Memory) Handle(entry logger.Entry) error {
+	defer s.lock()()
+	s.entries = append(s.entries, entry)
+	return nil
+}
+
+// CleanEntries will reset the in memory entries list
+func (s *Memory) CleanEntries() {
+	defer s.lock()()
+	s.entries = []logger.Entry{}
+}
+
+// GetEntries will return the in memory entries list
+func (s *Memory) GetEntries() []logger.Entry {
+	defer s.lock()()
+	return s.entries
+}
+
+// GetAndCleanEntries will return and clean the in memory entries list
+func (s *Memory) GetAndCleanEntries() []logger.Entry {
+	defer s.lock()()
+	entries := s.entries
+	s.entries = []logger.Entry{}
+	return entries
+}
+
+// NewMemory init a new Memory handler
+func NewMemory() *Memory {
+	return &Memory{}
+}

--- a/handler/memory_test.go
+++ b/handler/memory_test.go
@@ -1,0 +1,70 @@
+package handler_test
+
+import (
+	"testing"
+
+	"github.com/gol4ng/logger"
+	"github.com/gol4ng/logger/handler"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemory_Handle(t *testing.T) {
+	entry := logger.Entry{}
+
+	h := &handler.Memory{}
+
+	err := h.Handle(entry)
+	assert.NoError(t, err)
+
+	entries := h.GetEntries()
+	assert.Len(t, entries, 1)
+
+	assert.Equal(t, entry, entries[0])
+}
+
+func TestMemory_HandleRace(t *testing.T) {
+	h := &handler.Memory{}
+
+	go func() {
+		err := h.Handle(logger.Entry{})
+		assert.NoError(t, err)
+	}()
+
+	go func() {
+		h.GetEntries()
+	}()
+}
+
+func TestNewLogger_CleanEntries(t *testing.T) {
+	entry := logger.Entry{}
+
+	h := &handler.Memory{}
+
+	err := h.Handle(entry)
+	assert.NoError(t, err)
+
+	entries := h.GetEntries()
+	assert.Len(t, entries, 1)
+
+	assert.Equal(t, entry, entries[0])
+
+	h.CleanEntries()
+
+	assert.Empty(t, h.GetEntries())
+}
+
+func TestNewLogger_GetAndCleanEntries(t *testing.T) {
+	entry := logger.Entry{}
+
+	h := &handler.Memory{}
+
+	err := h.Handle(entry)
+	assert.NoError(t, err)
+
+	entries := h.GetAndCleanEntries()
+	assert.Len(t, entries, 1)
+
+	assert.Equal(t, entry, entries[0])
+
+	assert.Empty(t, h.GetEntries())
+}

--- a/handler/memory_test.go
+++ b/handler/memory_test.go
@@ -11,7 +11,7 @@ import (
 func TestMemory_Handle(t *testing.T) {
 	entry := logger.Entry{}
 
-	h := &handler.Memory{}
+	h := handler.NewMemory()
 
 	err := h.Handle(entry)
 	assert.NoError(t, err)
@@ -23,7 +23,7 @@ func TestMemory_Handle(t *testing.T) {
 }
 
 func TestMemory_HandleRace(t *testing.T) {
-	h := &handler.Memory{}
+	h := handler.NewMemory()
 
 	go func() {
 		err := h.Handle(logger.Entry{})
@@ -38,7 +38,7 @@ func TestMemory_HandleRace(t *testing.T) {
 func TestNewLogger_CleanEntries(t *testing.T) {
 	entry := logger.Entry{}
 
-	h := &handler.Memory{}
+	h := handler.NewMemory()
 
 	err := h.Handle(entry)
 	assert.NoError(t, err)
@@ -56,7 +56,7 @@ func TestNewLogger_CleanEntries(t *testing.T) {
 func TestNewLogger_GetAndCleanEntries(t *testing.T) {
 	entry := logger.Entry{}
 
-	h := &handler.Memory{}
+	h := handler.NewMemory()
 
 	err := h.Handle(entry)
 	assert.NoError(t, err)

--- a/testing/logger.go
+++ b/testing/logger.go
@@ -1,50 +1,12 @@
 package testing
 
 import (
-	"sync"
-
 	"github.com/gol4ng/logger"
+	"github.com/gol4ng/logger/handler"
 )
 
-type inMemoryEntriesStore struct {
-	mu      sync.Mutex
-	entries []logger.Entry
-}
-
-func (s *inMemoryEntriesStore) lock() func() {
-	s.mu.Lock()
-	return func() { s.mu.Unlock() }
-}
-
-// Handle act as logger.HandlerInterface
-func (s *inMemoryEntriesStore) Handle(entry logger.Entry) error {
-	defer s.lock()()
-	s.entries = append(s.entries, entry)
-	return nil
-}
-
-// CleanEntries will reset the in memory entries list
-func (s *inMemoryEntriesStore) CleanEntries() {
-	defer s.lock()()
-	s.entries = []logger.Entry{}
-}
-
-// GetEntries will return the in memory entries list
-func (s *inMemoryEntriesStore) GetEntries() []logger.Entry {
-	defer s.lock()()
-	return s.entries
-}
-
-// GetAndCleanEntries will return and clean the in memory entries list
-func (s *inMemoryEntriesStore) GetAndCleanEntries() []logger.Entry {
-	defer s.lock()()
-	entries := s.entries
-	s.entries = []logger.Entry{}
-	return entries
-}
-
-// NewLogger will return a new inMemory Logger in order to do some assertion during test
-func NewLogger() (*logger.Logger, *inMemoryEntriesStore) {
-	store := &inMemoryEntriesStore{}
+// NewLogger will return a new Memory Logger in order to do some assertion during test
+func NewLogger() (*logger.Logger, *handler.Memory) {
+	store := handler.NewMemory()
 	return logger.NewLogger(store.Handle), store
 }


### PR DESCRIPTION
move `testing.inMemoryEntriesStore` in `handler.Memory` to be public accessible 