### PR TITLE
Fixed output of JSON formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Available formatters:
 - **line** _it's just a `fmt.Sprintf` facade_ format:`%s %s %s` will produce `My log message info <my_key:my_value>`
 - **gelf** _format log entry to gelf_ `{"version":"1.1","host":"my_fake_hostname","level":6,"timestamp":513216000.000,"short_message":"My log message","full_message":"<info> My log message [ <my key:my_value> ]","_my_key":"my_value"}`
 - **json** _format log entry to json_ `{"Message":"My log message","Level":6,"Context":{"my_key":"my_value"}}`
+  - `WithJSONFlattenContext()`: Allows to put keys on a flatten way (not under `Context` key)
+  - `WithJSONLevelAsString()`: Allows to write the level entry as string: `notice`, `debug`, ...
 
 ## Middlewares
 

--- a/formatter/default.go
+++ b/formatter/default.go
@@ -55,7 +55,7 @@ func (n *DefaultFormatter) Format(entry logger.Entry) string {
 	}
 	if entry.Context != nil && n.displayContext(entry) {
 		builder.WriteString(" ")
-		ContextToJSON(entry.Context, builder)
+		ContextToJSON(entry.Context, builder, &JSONOptions{})
 	}
 	return builder.String()
 }

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -7,77 +7,141 @@ import (
 	"github.com/gol4ng/logger"
 )
 
+const (
+	// JsonMessageKey represents the reserved "message" key of a JSON log entry.
+	JsonMessageKey = "message"
+
+	// JsonLevelKey represents the reserved "level" key of a JSON log entry.
+	JsonLevelKey = "level"
+)
+
+type jsonEncodeFunc func(logger.Entry, *JSONOptions) ([]byte, error)
+
+// JSONOptions stores all the options used by the JSON formatter.
+type JSONOptions struct {
+	flatten       bool
+	levelAsString bool
+}
+
+// JSONOption represents a JSON option function available for this formatter.
+type JSONOption func(*JSONOptions)
+
+// WithJSONFlattenContext will flatten the context fields in the root JSON object.
+func WithJSONFlattenContext() JSONOption {
+	return func(o *JSONOptions) {
+		o.flatten = true
+	}
+}
+
+// WithJSONLevelAsString will render the level field as a string ("notice", "debug", ...)
+// instead of integer value.
+func WithJSONLevelAsString() JSONOption {
+	return func(o *JSONOptions) {
+		o.levelAsString = true
+	}
+}
+
 // JSON formatter will transform a logger entry into JSON
 // it takes an encode function that allows you to encode the data
 //
 // the encode function is useful if you do not use the default provided logger implementation
 type JSON struct {
-	encode func(logger.Entry) ([]byte, error)
+	encode  jsonEncodeFunc
+	options *JSONOptions
 }
 
 // Format will return Entry as json
 func (j *JSON) Format(entry logger.Entry) string {
-	b, _ := j.encode(entry)
+	b, _ := j.encode(entry, j.options)
 	return string(b)
 }
 
 // NewJSONEncoder will create a new JSON with default json encoder function
-func NewJSONEncoder() *JSON {
-	return NewJSON(JSONEncoder)
+func NewJSONEncoder(options ...JSONOption) *JSON {
+	return NewJSON(JSONEncoder, options...)
 }
 
 // NewJSON will create a new JSON with given json encoder
 // it allow you tu use your own json encoder
-func NewJSON(encode func(logger.Entry) ([]byte, error)) *JSON {
-	return &JSON{encode: encode}
+func NewJSON(encode jsonEncodeFunc, options ...JSONOption) *JSON {
+	opts := &JSONOptions{}
+
+	for _, option := range options {
+		option(opts)
+	}
+
+	return &JSON{
+		encode:  encode,
+		options: opts,
+	}
 }
 
 // ContextToJSON will marshall the logger context into json
-func ContextToJSON(context *logger.Context, builder *strings.Builder) {
+func ContextToJSON(context *logger.Context, builder *strings.Builder, options *JSONOptions) {
 	if context == nil || len(*context) == 0 {
-		builder.WriteString("null")
+		return
+	}
+
+	if options.flatten {
+		builder.WriteRune(',')
 	} else {
-		builder.WriteString("{")
-		i := 0
-		for name, field := range *context {
-			if i != 0 {
-				builder.WriteRune(',')
+		builder.WriteString(`,"Context":{`)
+	}
+
+	i := 0
+	for name, field := range *context {
+		if options.flatten {
+			// Avoid collisions on reserved keys when flattening.
+			switch name {
+			case JsonLevelKey, JsonMessageKey:
+				continue
 			}
-			builder.WriteRune('"')
-			builder.WriteString(name)
-			builder.WriteString("\":")
-			d, _ := field.MarshalJSON()
-			builder.Write(d)
-			i++
 		}
-		builder.WriteString("}")
+
+		if i != 0 {
+			builder.WriteRune(',')
+		}
+		builder.WriteRune('"')
+		builder.WriteString(name)
+		builder.WriteString(`":`)
+		d, _ := field.MarshalJSON()
+		builder.Write(d)
+		i++
+	}
+
+	if !options.flatten {
+		builder.WriteString(`}`)
 	}
 }
 
 // EntryToJSON will marshall the logger Entry into json
-func EntryToJSON(entry logger.Entry, builder *strings.Builder) {
+func EntryToJSON(entry logger.Entry, builder *strings.Builder, options *JSONOptions) {
 	builder.WriteRune('{')
 
-	builder.WriteString("\"Message\":\"")
+	builder.WriteString(`"message":"`)
 	builder.WriteString(entry.Message)
-	builder.WriteString("\"")
+	builder.WriteRune('"')
 
 	builder.WriteRune(',')
-	builder.WriteString("\"Level\":")
-	builder.WriteString(strconv.Itoa(int(entry.Level)))
+	builder.WriteString(`"level":"`)
 
-	builder.WriteRune(',')
-	builder.WriteString("\"Context\":")
+	if options.levelAsString {
+		builder.WriteString(entry.Level.String())
+	} else {
+		builder.WriteString(strconv.Itoa(int(entry.Level)))
+	}
 
-	ContextToJSON(entry.Context, builder)
+	builder.WriteRune('"')
+
+	ContextToJSON(entry.Context, builder, options)
 
 	builder.WriteRune('}')
 }
 
 // JSONEncoder will return Entry to json string
-func JSONEncoder(entry logger.Entry) ([]byte, error) {
+func JSONEncoder(entry logger.Entry, options *JSONOptions) ([]byte, error) {
 	builder := &strings.Builder{}
-	EntryToJSON(entry, builder)
+	EntryToJSON(entry, builder, options)
 
 	return []byte(builder.String()), nil
 }

--- a/formatter/json_test.go
+++ b/formatter/json_test.go
@@ -1,6 +1,7 @@
 package formatter_test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -16,25 +17,166 @@ func TestJson_Format(t *testing.T) {
 	tests := []struct {
 		name     string
 		entry    logger.Entry
-		expected string
+		options  []formatter.JSONOption
+		expected map[string]interface{}
 	}{
 		{
-			name:     "test simple message without context",
-			entry:    logger.Entry{Message: "test message", Level: logger.DebugLevel, Context: nil},
-			expected: `{"Message":"test message","Level":7,"Context":null}`,
+			name:    "test simple message without context",
+			entry:   logger.Entry{Message: "test message", Level: logger.DebugLevel, Context: nil},
+			options: []formatter.JSONOption{},
+			expected: map[string]interface{}{
+				"message": "test message",
+				"level":   "7",
+			},
 		},
 		{
-			name:     "test simple message with context",
-			entry:    logger.Entry{Message: "test message", Level: logger.WarningLevel, Context: logger.NewContext().Add("my_key", "my_value")},
-			expected: `{"Message":"test message","Level":4,"Context":{"my_key":"my_value"}}`,
+			name:  "test simple message without context and levelAsString option",
+			entry: logger.Entry{Message: "test message", Level: logger.DebugLevel, Context: nil},
+			options: []formatter.JSONOption{
+				formatter.WithJSONLevelAsString(),
+			},
+			expected: map[string]interface{}{
+				"message": "test message",
+				"level":   "debug",
+			},
+		},
+		{
+			name:    "test simple message with context",
+			entry:   logger.Entry{Message: "test message", Level: logger.WarningLevel, Context: logger.NewContext().Add("my_key", "my_value")},
+			options: []formatter.JSONOption{},
+			expected: map[string]interface{}{
+				"message": "test message",
+				"level":   "4",
+				"Context": map[string]interface{}{
+					"my_key": "my_value",
+				},
+			},
+		},
+		{
+			name:  "test simple message with context and flatten and levelAsString options",
+			entry: logger.Entry{Message: "test message", Level: logger.WarningLevel, Context: logger.NewContext().Add("my_key", "my_value")},
+			options: []formatter.JSONOption{
+				formatter.WithJSONFlattenContext(),
+				formatter.WithJSONLevelAsString(),
+			},
+			expected: map[string]interface{}{
+				"message": "test message",
+				"level":   "warning",
+				"my_key":  "my_value",
+			},
+		},
+		{
+			name: "test simple message with context and multiple fields",
+			entry: logger.Entry{
+				Message: "test message",
+				Level:   logger.ErrorLevel,
+				Context: logger.NewContext().
+					Add("my_key_1", "my_value_1").
+					Add("my_key_2", "my_value_2"),
+			},
+			options: []formatter.JSONOption{},
+			expected: map[string]interface{}{
+				"message": "test message",
+				"level":   "3",
+				"Context": map[string]interface{}{
+					"my_key_1": "my_value_1",
+					"my_key_2": "my_value_2",
+				},
+			},
+		},
+		{
+			name: "test simple message with context and multiple fields and flatten and levelAsString options",
+			entry: logger.Entry{
+				Message: "test message",
+				Level:   logger.ErrorLevel,
+				Context: logger.NewContext().
+					Add("my_key_1", "my_value_1").
+					Add("my_key_2", "my_value_2"),
+			},
+			options: []formatter.JSONOption{
+				formatter.WithJSONFlattenContext(),
+				formatter.WithJSONLevelAsString(),
+			},
+			expected: map[string]interface{}{
+				"message":  "test message",
+				"level":    "error",
+				"my_key_1": "my_value_1",
+				"my_key_2": "my_value_2",
+			},
+		},
+		{
+			name: "test simple message with context and multiple fields and duplicated field",
+			entry: logger.Entry{
+				Message: "test message",
+				Level:   logger.ErrorLevel,
+				Context: logger.NewContext().
+					Add("my_key_1", "my_value_1").
+					Add("my_key_1", "my_value_1").
+					Add("my_key_2", "my_value_2"),
+			},
+			options: []formatter.JSONOption{},
+			expected: map[string]interface{}{
+				"message": "test message",
+				"level":   "3",
+				"Context": map[string]interface{}{
+					"my_key_1": "my_value_1",
+					"my_key_2": "my_value_2",
+				},
+			},
+		},
+		{
+			name: "test simple message with context and with usage of reserved keys (should appear)",
+			entry: logger.Entry{
+				Message: "test message",
+				Level:   logger.ErrorLevel,
+				Context: logger.NewContext().
+					Add("message", "my test message").
+					Add("level", "a level entry"),
+			},
+			options: []formatter.JSONOption{},
+			expected: map[string]interface{}{
+				"message": "test message",
+				"level":   "3",
+				"Context": map[string]interface{}{
+					"message": "my test message",
+					"level":   "a level entry",
+				},
+			},
+		},
+		{
+			name: "test simple message with context, flatten and with reserved keys (should not appear)",
+			entry: logger.Entry{
+				Message: "test message",
+				Level:   logger.ErrorLevel,
+				Context: logger.NewContext().
+					Add("my_key_1", "my_value_1").
+					Add("message", "my test message that should not appear").
+					Add("level", "a level entry that should not appear").
+					Add("my_key_2", "my_value_2"),
+			},
+			options: []formatter.JSONOption{
+				formatter.WithJSONFlattenContext(),
+			},
+			expected: map[string]interface{}{
+				"message":  "test message",
+				"level":    "3",
+				"my_key_1": "my_value_1",
+				"my_key_2": "my_value_2",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := formatter.NewJSONEncoder()
+			f := formatter.NewJSONEncoder(tt.options...)
+			result := f.Format(tt.entry)
 
-			assert.Equal(t, tt.expected, f.Format(tt.entry))
+			got := map[string]interface{}{}
+			if err := json.Unmarshal([]byte(result), &got); err != nil {
+				assert.Fail(t, "unable to unmarshal result", result)
+			}
+
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }
@@ -43,31 +185,37 @@ func TestMarshalContextTo(t *testing.T) {
 	tests := []struct {
 		name            string
 		context         *logger.Context
+		options         *formatter.JSONOptions
 		expectedStrings []string
 	}{
 		{
 			name:            "test simple message without context",
 			context:         nil,
-			expectedStrings: []string{"null"},
+			options:         &formatter.JSONOptions{},
+			expectedStrings: []string{""},
 		},
 		{
 			name:            "test simple message with context",
 			context:         logger.NewContext().Add("my_key", "my_value"),
-			expectedStrings: []string{`{"my_key":"my_value"}`},
+			options:         &formatter.JSONOptions{},
+			expectedStrings: []string{`"my_key":"my_value"`},
 		},
 		{
 			name:            "test multiple message with context",
 			context:         logger.NewContext().Add("my_key", "my_value").Add("my_key2", "my_value2"),
-			expectedStrings: []string{`my_key":"my_value"`, `"my_key2":"my_value2"`},
+			options:         &formatter.JSONOptions{},
+			expectedStrings: []string{`"my_key":"my_value"`, `"my_key2":"my_value2"`},
 		},
 		{
 			name:            "test time message with context",
 			context:         logger.NewContext().Add("my_key", time.Date(2020, 1, 2, 3, 4, 5, 6, time.UTC)),
+			options:         &formatter.JSONOptions{},
 			expectedStrings: []string{`my_key":"2020-01-02T03:04:05.000000006Z"`},
 		},
 		{
 			name:            "test time message with context",
 			context:         logger.NewContext().Add("my_key", errors.New("my error message")),
+			options:         &formatter.JSONOptions{},
 			expectedStrings: []string{`my_key":"my error message"`},
 		},
 	}
@@ -75,7 +223,7 @@ func TestMarshalContextTo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			builder := &strings.Builder{}
-			formatter.ContextToJSON(tt.context, builder)
+			formatter.ContextToJSON(tt.context, builder, tt.options)
 			str := builder.String()
 			for _, s := range tt.expectedStrings {
 				assert.Contains(t, str, s)
@@ -99,5 +247,5 @@ func ExampleJsonFormatter() {
 		},
 	))
 	//Output:
-	//{"Message":"My log message","Level":6,"Context":{"my_key":"my_value"}}
+	//{"message":"My log message","level":"6","Context":{"my_key":"my_value"}}
 }


### PR DESCRIPTION
The JSON formatter had some issues:

* The "static" field names (message, level) were capitalized, I think it's better to have them in lowercase,
* The `level` field output was the integer value when it should be the string value (`notice`, `debug`, `info`, `error`, ...)

Concerning the Context, when you add some fields into it using the following code for instance:
```go
log2 := log.WrapNew(
	middleware.Context(
		logger.NewContext().SetField(
			logger.Any("trace_id", "123"),
		),
	),
)
```

the result is under a `Context` key:
```json
{"Message": "something", "Level":6, "Context": {"trace_id": "123"}}
```
which I think users are waiting to have fields at root of the log message:
```json
{"message": "something", "level":"debug", "trace_id": "123"}
```